### PR TITLE
Fix: Correct user ID usage in agent creation webhook

### DIFF
--- a/app/api/Concierge/create/route.ts
+++ b/app/api/Concierge/create/route.ts
@@ -87,37 +87,25 @@ export async function POST(req: NextRequest) {
     
     if (isWebhookCall) {
       // For webhook calls, use admin client and get user from payment session
-      console.log('Webhook call detected, using admin client to fetch user from payment session');
+      console.log('Webhook call detected, using admin client to fetch user_id from payment_sessions table.');
       dbClient = createAdminClient();
       
       const { data: paymentSessionData, error: paymentSessionError } = await dbClient
         .from('payment_sessions')
-        .select('user_id')
+        .select('user_id') // This user_id references public.users.id
         .eq('id', paymentSessionId)
         .single();
         
-      if (paymentSessionError || !paymentSessionData) {
-        console.error('Error fetching payment session for webhook:', paymentSessionError);
-        return NextResponse.json({ error: 'Payment session not found' }, { status: 404 });
+      if (paymentSessionError || !paymentSessionData || !paymentSessionData.user_id) {
+        console.error('Error fetching user_id from payment_sessions for webhook:', paymentSessionError, 'or user_id is null.');
+        return NextResponse.json({ error: 'Valid payment session with user_id not found' }, { status: 404 });
       }
       
-      const authUserId = paymentSessionData.user_id;
-      console.log('Retrieved auth user ID from payment session:', authUserId);
+      userId = paymentSessionData.user_id; // This is the correct application user ID (public.users.id)
+      console.log('Retrieved application user_id from payment_sessions:', userId);
       
-      // Look up the actual user_id from the users table using the auth_user_id
-      const { data: userData, error: userLookupError } = await dbClient
-        .from('users')
-        .select('id')
-        .eq('auth_user_id', authUserId)
-        .single();
-        
-      if (userLookupError || !userData) {
-        console.error('Error finding user record with auth_user_id:', authUserId, userLookupError);
-        return NextResponse.json({ error: 'User record not found' }, { status: 404 });
-      }
-      
-      userId = userData.id;
-      console.log('Found actual user_id for assistant creation:', userId);
+      // The previous lookup for userData using auth_user_id is removed as it was incorrect.
+      // We now directly use the user_id from payment_sessions.
     } else {
       // For regular calls, authenticate the user
       const supabase = await createClient();

--- a/app/api/Concierge/session/route.ts
+++ b/app/api/Concierge/session/route.ts
@@ -87,6 +87,18 @@ export async function GET(req: NextRequest) {
   }
 }
 
+// IMPORTANT DATABASE SCHEMA NOTE:
+// The successful operation of this POST handler, especially the insertion into 'payment_sessions',
+// depends on the database schema matching the state defined after the migration
+// 'supabase/migrations/20250603120000_fix_payment_sessions_user_id_fkey.sql'.
+// Specifically:
+// 1. The 'payment_sessions.user_id' column MUST reference 'public.users.id' (the application user ID).
+// 2. The RLS policy "Users can insert their own payment sessions" ON 'public.payment_sessions'
+//    MUST validate against 'public.users.auth_user_id' matching 'auth.uid()', and use the
+//    'public.users.id' for the 'user_id' field being inserted.
+// If these conditions are not met (e.g., if the 'payment_sessions.user_id' still references 'auth.users.id'
+// or RLS policies are outdated), this endpoint may return a 500 error with the message
+// "Failed to create payment session" due to RLS check failures.
 export async function POST(req: NextRequest) {
   try {
     const supabase = await createClient();


### PR DESCRIPTION
- Modified `app/api/Concierge/create/route.ts` to correctly use the application user ID (`public.users.id`) from the `payment_sessions` table when creating an assistant via a webhook call. Previously, it incorrectly treated this ID as an `auth_user_id` and performed an unnecessary and potentially erroneous lookup.

Doc: Add note on DB schema for payment session creation

- Added a comment in `app/api/Concierge/session/route.ts` to highlight that the successful creation of payment sessions relies on the database schema and RLS policies being aligned with the migration `supabase/migrations/20250603120000_fix_payment_sessions_user_id_fkey.sql`. This is to aid debugging if errors like "Failed to create payment session" occur due to environment inconsistencies.